### PR TITLE
archiver class name translation for digits session data

### DIFF
--- a/DigitsMigrationHelper/Classes/SessionStore.m
+++ b/DigitsMigrationHelper/Classes/SessionStore.m
@@ -30,6 +30,12 @@ NSString *const FIRDigitsMigratorClearAuthErrorUserIDKey = @"userID";
   self = [super init];
   if (self) {
       _keychain = keychain;
+
+      // Map old archived DGTSession data into new FIRDigitsSession data
+      static dispatch_once_t onceToken = 0;
+      dispatch_once(&onceToken, ^{
+          [NSKeyedUnarchiver setClass:[FIRDigitsSession class] forClassName:@"DGTSession"];
+      });
   }
   return self;
 }

--- a/Example/DigitsMigrationHelper-Example/AppDelegate.m
+++ b/Example/DigitsMigrationHelper-Example/AppDelegate.m
@@ -35,8 +35,9 @@
 
   [FIRApp configure];
 
-  [[Digits sharedInstance] startWithConsumerKey:key consumerSecret:secret];
-  //[Fabric with:@[[Digits class]]];
+  if (key && secret) {
+    [[Digits sharedInstance] startWithConsumerKey:key consumerSecret:secret];
+  }
 
   return YES;
 }

--- a/Example/DigitsMigrationHelper.xcodeproj/project.pbxproj
+++ b/Example/DigitsMigrationHelper.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		6003F5B1195388D20070C39A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F58D195388D20070C39A /* Foundation.framework */; };
 		6003F5B2195388D20070C39A /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6003F591195388D20070C39A /* UIKit.framework */; };
 		6003F5BC195388D20070C39A /* Tests.m in Sources */ = {isa = PBXBuildFile; fileRef = 6003F5BB195388D20070C39A /* Tests.m */; };
+		ADAA888C1ED8CEBA00245826 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ADAA888B1ED8CEBA00245826 /* GoogleService-Info.plist */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -66,6 +67,7 @@
 		6FF607CB1E9452F2009D77D2 /* DigitsMigrationHelper_Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DigitsMigrationHelper_Example.entitlements; sourceTree = "<group>"; };
 		8A6978B18D3308AAE0EDE4AF /* README.md */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = net.daringfireball.markdown; name = README.md; path = ../README.md; sourceTree = "<group>"; };
 		9A0C7D1B95C84EBB5AF78CD4 /* DigitsMigrationHelper.podspec */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = DigitsMigrationHelper.podspec; path = ../DigitsMigrationHelper.podspec; sourceTree = "<group>"; };
+		ADAA888B1ED8CEBA00245826 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F7F4B37E77AA21F4F401CCB9 /* LICENSE */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -190,6 +192,7 @@
 		6003F5B6195388D20070C39A /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				ADAA888B1ED8CEBA00245826 /* GoogleService-Info.plist */,
 				6003F5B7195388D20070C39A /* Tests-Info.plist */,
 			);
 			name = "Supporting Files";
@@ -330,6 +333,7 @@
 			files = (
 				10B345B11EBD6AD900B09893 /* Example-Info.plist in Resources */,
 				10B345AE1EBD6ACA00B09893 /* Main.storyboard in Resources */,
+				ADAA888C1ED8CEBA00245826 /* GoogleService-Info.plist in Resources */,
 				10C6E6E31EC275F600B388E2 /* LaunchScreen.xib in Resources */,
 				10C6E6E01EC275F600B388E2 /* Images.xcassets in Resources */,
 			);

--- a/Example/Tests/GoogleService-Info.plist
+++ b/Example/Tests/GoogleService-Info.plist
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>AD_UNIT_ID_FOR_BANNER_TEST</key>
+	<string>id</string>
+	<key>AD_UNIT_ID_FOR_INTERSTITIAL_TEST</key>
+	<string>id</string>
+	<key>CLIENT_ID</key>
+	<string>client_id</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>id</string>
+	<key>API_KEY</key>
+	<string>api_key</string>
+	<key>GCM_SENDER_ID</key>
+	<string>id</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>bundle_id</string>
+	<key>PROJECT_ID</key>
+	<string>project_id</string>
+	<key>STORAGE_BUCKET</key>
+	<string>bucket_id</string>
+	<key>IS_ADS_ENABLED</key>
+	<true/>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false/>
+	<key>IS_APPINVITE_ENABLED</key>
+	<false/>
+	<key>IS_GCM_ENABLED</key>
+	<true/>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true/>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:395728172828:ios:d08bf73101f30fd8</string>
+	<key>DATABASE_URL</key>
+	<string>http://google.com</string>
+</dict>
+</plist>


### PR DESCRIPTION
@ulukaya , @paulb777 , please help take a look on this bug fix. This is causing the crash issue as reported in https://github.com/firebase/digits-migration-helper-ios/issues/2 since the old archived data is encoded with DGTSession class that's not available after Digits kit removed.